### PR TITLE
Fix: Handle bad images without causing NOP inputs from user

### DIFF
--- a/image_viewer/__main__.py
+++ b/image_viewer/__main__.py
@@ -36,4 +36,4 @@ if __name__ == "__main__" and len(sys.argv) > 1:  # pragma: no cover
     if not __debug__:
         sys.excepthook = partial(exception_hook, destination_folder=path_to_exe_folder)
 
-    ViewerApp(sys.argv[1], path_to_exe_folder)
+    ViewerApp(sys.argv[1], path_to_exe_folder).start()

--- a/image_viewer/config.py
+++ b/image_viewer/config.py
@@ -14,23 +14,27 @@ DEFAULT_BACKGROUND_COLOR: str = "#000000"
 
 
 def _validate_hex_or_default(hex_color: str, default: str) -> str:
-    """Returns hex_color if its in the valid hex format or default if not"""
+    """Returns hex_color if its in the valid hex format or default if not
+
+    :param hex_color: A possible hex color
+    :param default: What to return if hex_color is invalid
+    :returns: Either hex_color if its valid or default"""
 
     return hex_color if is_valid_hex_color(hex_color) else default
 
 
 def _validate_keybind_or_default(keybind: str, default: str) -> str:
-    """Returns keybind if it follows the format:
+    """Returns keybind if its in a valid format or default if not
 
-    <F[0-9]> <F1[0-2]> <Control-[a-zA-Z0-9]>
-
-    or default if not"""
+    :param keybind: A possible keybind
+    :param default: What to return if keybind is invalid
+    :returns: Either keybind if its valid or default"""
 
     return keybind if is_valid_keybind(keybind) else default
 
 
 class DefaultKeybinds(StrEnum):
-    """Defaults for keybinds that config.ini can override"""
+    """Defaults for keybinds that config.ini can override."""
 
     COPY_TO_CLIPBOARD_AS_BASE64 = "<Control-E>"
     MOVE_TO_NEW_FILE = "<Control-m>"
@@ -42,7 +46,7 @@ class DefaultKeybinds(StrEnum):
 
 
 class Config:
-    """Reads configs from config.ini"""
+    """Reads values from config.ini file."""
 
     __slots__ = ("background_color", "font_file", "keybinds", "max_items_in_cache")
 
@@ -78,7 +82,7 @@ class Config:
 
 
 class KeybindConfig:
-    """Contains configurable tkinter keybinds"""
+    """Contains configurable tkinter keybinds."""
 
     __slots__ = (
         "copy_to_clipboard_as_base64",
@@ -122,10 +126,10 @@ class KeybindConfig:
 
 
 class ConfigParserExt(ConfigParser):
-    """Extends ConfigParser to add safer implementations of get"""
+    """Extends ConfigParser to add safer implementations of get."""
 
     def get_int_safe(self, section: str, option: str, fallback: int) -> int:
-        """Returns config option converted to int or default if convert fails"""
+        """Returns config option converted to int or default if convert fails."""
         try:
             result: int = int(super().get(section, option, fallback=fallback))
         except ValueError:
@@ -134,7 +138,7 @@ class ConfigParserExt(ConfigParser):
         return result
 
     def get_string_safe(self, section: str, option: str, fallback: str = "") -> str:
-        """Returns config option as string or default if missing or empty"""
+        """Returns config option as string or default if missing or empty."""
         result: str = super().get(section, option, fallback=fallback).strip("'\"")
 
         return result or fallback

--- a/image_viewer/constants.py
+++ b/image_viewer/constants.py
@@ -40,6 +40,14 @@ class ZoomDirection(IntEnum):
     OUT = -1
 
 
+class Movement(IntEnum):
+    """Common movement amounts between images"""
+
+    FORWARD = 1
+    NONE = 0
+    BACKWARD = -1
+
+
 class TkTags(StrEnum):
     """Tags for items on the UI"""
 

--- a/image_viewer/files/file_manager.py
+++ b/image_viewer/files/file_manager.py
@@ -8,7 +8,7 @@ from PIL.Image import Image
 
 from actions.types import Convert, Delete, Rename
 from actions.undoer import ActionUndoer, UndoResponse
-from constants import VALID_FILE_TYPES
+from constants import VALID_FILE_TYPES, Movement
 from files.file_dialog_asker import FileDialogAsker
 from image.cache import ImageCache, ImageCacheEntry
 from image.file import ImageName, ImageNameList
@@ -198,13 +198,13 @@ class ImageFileManager:
             pass
         self.remove_current_image()
 
-    def remove_current_image(self, move_backwards: bool = False) -> None:
+    def remove_current_image(self, index_movement: Movement = Movement.NONE) -> None:
         """Removes current image from files list and cache.
 
-        :param move_backwards: Sets the current image to be the previous one
-        in order rather than the next one."""
+        :param index_movement: The direction to move the index. If NONE passed,
+        index will try to preserve its current position."""
 
-        self._files.remove_current_image(move_backwards)
+        self._files.remove_current_image(index_movement)
         self.image_cache.pop_safe(self.path_to_image)
         self._update_after_move_or_edit()
 

--- a/image_viewer/image/file.py
+++ b/image_viewer/image/file.py
@@ -68,11 +68,20 @@ class ImageNameList(list[ImageName]):
 
         image_count: int = len(self)
 
-        if index_movement == Movement.NONE:
-            if self._display_index >= image_count:
+        # Weird logic here: moving BACKWARD is normal
+        # but, if FORWARD then we need to do nothing since
+        # keeping index the same and removing an item from the list
+        # will effectively move forward. However, if index now exceeds
+        # the list size, when NONE we need to wrap back to the end of the list
+        # to preserve being at the end of the list. if FORWARD we need to wrap
+        # around to index 0
+        if index_movement == Movement.BACKWARD:
+            self.move_index(-1)
+        elif self._display_index >= image_count:
+            if index_movement == Movement.NONE:
                 self._display_index = image_count - 1
-        else:
-            self.move_index(index_movement)
+            else:  # Must be Movement.FORWARD
+                self._display_index = 0
 
     def get_index_of_image(self, target_image: str) -> ImageSearchResult:
         """Finds index of target_image.

--- a/image_viewer/image/file.py
+++ b/image_viewer/image/file.py
@@ -3,7 +3,7 @@
 from collections import namedtuple
 from typing import Iterable
 
-from constants import ImageFormats
+from constants import ImageFormats, Movement
 from util.os import os_name_cmp
 
 
@@ -56,11 +56,11 @@ class ImageNameList(list[ImageName]):
         super().sort()
         self._display_index, _ = self.get_index_of_image(image_to_start_at)
 
-    def remove_current_image(self, move_backwards: bool = False) -> None:
+    def remove_current_image(self, index_movement: Movement = Movement.NONE) -> None:
         """Safely removes the entry at the current index.
 
-        :param move_backwards: Sets the display index back one. By default,
-        not editing the index will effectively move the index forward."""
+        :param index_movement: The direction to move the index. If NONE passed,
+        index will try to preserve its current position."""
         try:
             super().pop(self._display_index)
         except IndexError:
@@ -68,10 +68,11 @@ class ImageNameList(list[ImageName]):
 
         image_count: int = len(self)
 
-        if move_backwards:
-            self.move_index(-1)
-        elif self._display_index >= image_count:
-            self._display_index = image_count - 1
+        if index_movement == Movement.NONE:
+            if self._display_index >= image_count:
+                self._display_index = image_count - 1
+        else:
+            self.move_index(index_movement)
 
     def get_index_of_image(self, target_image: str) -> ImageSearchResult:
         """Finds index of target_image.

--- a/image_viewer/image/file.py
+++ b/image_viewer/image/file.py
@@ -45,9 +45,6 @@ class ImageNameList(list[ImageName]):
     def get_current_image(self) -> ImageName:
         return self[self._display_index]
 
-    def get_current_image_name(self) -> str:
-        return self[self._display_index].name
-
     def move_index(self, amount: int) -> None:
         """Moves display_index by the provided amount with wraparound"""
         image_count: int = len(self)
@@ -59,8 +56,11 @@ class ImageNameList(list[ImageName]):
         super().sort()
         self._display_index, _ = self.get_index_of_image(image_to_start_at)
 
-    def remove_current_image(self) -> None:
-        """Safely removes current index"""
+    def remove_current_image(self, move_backwards: bool = False) -> None:
+        """Safely removes the entry at the current index.
+
+        :param move_backwards: Sets the display index back one. By default,
+        not editing the index will effectively move the index forward."""
         try:
             super().pop(self._display_index)
         except IndexError:
@@ -68,7 +68,9 @@ class ImageNameList(list[ImageName]):
 
         image_count: int = len(self)
 
-        if self._display_index >= image_count:
+        if move_backwards:
+            self.move_index(-1)
+        elif self._display_index >= image_count:
             self._display_index = image_count - 1
 
     def get_index_of_image(self, target_image: str) -> ImageSearchResult:

--- a/image_viewer/util/_generic.pyi
+++ b/image_viewer/util/_generic.pyi
@@ -1,8 +1,15 @@
 """Utility functions that aren't better classified in other files"""
 
 def is_valid_hex_color(hex_color: str) -> bool:
-    """Given a hex color string in format #123456, return True if it is valid"""
+    """Checks if a string is a valid hex color in the case-insensitive format '#ABC123'.
+
+    :param hex_color: A possible hex color
+    :returns: True if hex_color is a valid color"""
 
 def is_valid_keybind(keybind: str) -> bool:
-    """Given a keybind, returns True if it matches one of the following formats
-    <F[0-9]> <F1[0-2]> <Control-[a-zA-Z0-9]>"""
+    """Checks if a keybind is a valid subset of tkinter keybinds allowed in this program.
+
+    :param keybind: A possible keybind
+    :returns: True if keybind follows one of the following regex:
+    <F[0-9]> <F1[0-2]> <Control-[a-zA-Z0-9]>
+    """

--- a/image_viewer/util/io.py
+++ b/image_viewer/util/io.py
@@ -59,9 +59,10 @@ def try_convert_file_and_save_new(
 
 
 def read_memory_as_base64(image_buffer: memoryview) -> str:
-    """Given a memory view, decode it into a base64 string.
+    """Decodes some memory into a base64 string.
 
-    Errors are ignored during byte -> str conversion."""
+    :param image_buffer: The memory buffer of an image to decode
+    :returns: The decoded base64"""
 
     return binascii.b2a_base64(image_buffer, newline=False).decode(
         "ascii", errors="ignore"

--- a/image_viewer/util/os.py
+++ b/image_viewer/util/os.py
@@ -147,6 +147,7 @@ def split_name_and_suffix(name_and_suffix: str) -> tuple[str, str]:
 
 
 def get_path_to_exe_folder() -> str:
-    """Returns path to folder containing exe/py file
-    of running program"""
+    """Returns the folder path containing the file running the program
+
+    :returns: The folder path"""
     return os.path.dirname(sys.argv[0])

--- a/requirements_compile.txt
+++ b/requirements_compile.txt
@@ -1,3 +1,3 @@
 nuitka==2.7.12
-personal-python-ast-optimizer @ git+https://github.com/jbjd/Python-Ast-Optimizer@v2.3.2
+personal-python-ast-optimizer @ git+https://github.com/jbjd/Python-Ast-Optimizer@v2.3.3
 personal-compile-tools @ git+https://github.com/jbjd/Compile-Tools@v1.1.0

--- a/requirements_compile.txt
+++ b/requirements_compile.txt
@@ -1,3 +1,3 @@
-nuitka==2.7.12
+nuitka==2.7.13
 personal-python-ast-optimizer @ git+https://github.com/jbjd/Python-Ast-Optimizer@v2.3.3
 personal-compile-tools @ git+https://github.com/jbjd/Compile-Tools@v1.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ define other constants used within tests"""
 
 import os
 from tkinter import Tk
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL.Image import Image
@@ -90,31 +90,31 @@ def rename_entry_fixture(tk_app: Tk, canvas: CustomCanvas) -> RenameEntry:
     return RenameEntry(tk_app, canvas, rename_id, 250, DEFAULT_FONT)
 
 
-@pytest.fixture(name="partial_viewer")
-def partial_viewer_fixture(
-    tk_app: Tk, image_loader: ImageLoader, file_manager
-) -> ViewerApp:
-    """A Viewer object that's not properly initialized.
-    Can be used to test standalone parts of the class"""
+@pytest.fixture(name="viewer")
+def viewer_fixture() -> ViewerApp:
+    """A Viewer object with visual UI elements mocked out"""
 
-    def mock_viewer_init(self, *_):
-        self.app = tk_app
-        self.file_manager = file_manager
-        self.image_loader = image_loader
-        self.animation_id = ""
-        self.move_id = ""
-        self.need_to_redraw = False
+    # This function needs to be unpacked so we must explicitly define it
+    mock_icon_factory = MagicMock()
+    mock_icon_factory.return_value.make_dropdown_icons.return_value = (
+        MagicMock(),
+        MagicMock(),
+    )
 
-    with patch.object(ViewerApp, "__init__", mock_viewer_init):
-        return ViewerApp("", "")
-
-
-@pytest.fixture(name="focused_event", scope="module")
-def focused_event_fixture(tk_app: Tk) -> MockEvent:
-    return MockEvent(tk_app)
+    with (
+        patch.object(ViewerApp, "_init_image_display"),
+        patch("image_viewer.viewer.CustomCanvas"),
+        patch("image_viewer.viewer.ButtonIconFactory", mock_icon_factory),
+    ):
+        return ViewerApp(EXAMPLE_IMG_PATH, CODE_DIR)
 
 
-@pytest.fixture(name="unfocused_event", scope="module")
+@pytest.fixture(name="focused_event")
+def focused_event_fixture(viewer: ViewerApp) -> MockEvent:
+    return MockEvent(viewer.app)
+
+
+@pytest.fixture(name="unfocused_event")
 def unfocused_event_fixture() -> MockEvent:
     return MockEvent()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,7 @@ def viewer_fixture() -> ViewerApp:
 
     with (
         patch.object(ViewerApp, "_init_image_display"),
+        patch("image_viewer.viewer.Tk"),
         patch("image_viewer.viewer.CustomCanvas"),
         patch("image_viewer.viewer.ButtonIconFactory", mock_icon_factory),
     ):

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -18,7 +18,7 @@ def test_image_file_manager(file_manager: ImageFileManager):
     """Test various functions of the file manager with empty image files"""
     assert len(file_manager._files) == 1
 
-    file_manager.find_all_images()
+    file_manager.update_files_with_known_starting_image()
     assert len(file_manager._files) == 4
     assert file_manager._files.get_index_of_image("a.png") == (0, True)
 
@@ -210,7 +210,7 @@ def test_split_with_weird_names(file_manager: ImageFileManager):
 def test_move_to_new_file(file_manager: ImageFileManager):
     """When user chooses a file in file dialog, should move to selected file"""
     chosen_path: str = os.path.join(IMG_DIR, "d.jpg")
-    file_manager.image_directory = "some/path"
+    file_manager.image_folder = "some/path"
 
     with patch(
         "image_viewer.files.file_manager.FileDialogAsker.ask_open_image",
@@ -218,7 +218,7 @@ def test_move_to_new_file(file_manager: ImageFileManager):
     ):
         assert file_manager.move_to_new_file()
         assert file_manager.path_to_image == chosen_path
-        assert file_manager.image_directory == IMG_DIR
+        assert file_manager.image_folder == IMG_DIR
 
 
 def test_move_to_new_file_cancelled(file_manager: ImageFileManager):

--- a/tests/test_image_file.py
+++ b/tests/test_image_file.py
@@ -1,7 +1,7 @@
 import pytest
 
-from image_viewer.constants import ImageFormats
-from image_viewer.image.file import magic_number_guess
+from image_viewer.constants import ImageFormats, Movement
+from image_viewer.image.file import magic_number_guess, ImageName, ImageNameList
 
 
 @pytest.mark.parametrize(
@@ -19,3 +19,36 @@ from image_viewer.image.file import magic_number_guess
 def test_magic_number_guess(magic_bytes: bytes, expected_format: ImageFormats):
     """Ensure correct image type guessed"""
     assert magic_number_guess(magic_bytes) == expected_format
+
+
+@pytest.mark.parametrize(
+    "index_movement,starting_index,expected_index",
+    [
+        (Movement.BACKWARD, 0, 3),
+        (Movement.NONE, 0, 0),
+        (Movement.FORWARD, 0, 0),
+        (Movement.BACKWARD, 2, 1),
+        (Movement.NONE, 2, 2),
+        (Movement.FORWARD, 2, 2),
+        (Movement.BACKWARD, 4, 3),
+        (Movement.NONE, 4, 3),
+        (Movement.FORWARD, 4, 0),
+    ],
+)
+def test_remove_current_image(
+    index_movement: Movement, starting_index: int, expected_index: int
+):
+    image_names = ImageNameList(
+        [
+            ImageName("a.png"),
+            ImageName("b.png"),
+            ImageName("c.png"),
+            ImageName("d.png"),
+            ImageName("e.png"),
+        ]
+    )
+    image_names._display_index = starting_index
+
+    image_names.remove_current_image(index_movement)
+
+    assert image_names._display_index == expected_index

--- a/tests/test_image_file.py
+++ b/tests/test_image_file.py
@@ -1,7 +1,7 @@
 import pytest
 
 from image_viewer.constants import ImageFormats, Movement
-from image_viewer.image.file import magic_number_guess, ImageName, ImageNameList
+from image_viewer.image.file import ImageName, ImageNameList, magic_number_guess
 
 
 @pytest.mark.parametrize(

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -9,6 +9,8 @@ from tests.test_util.mocks import MockEvent
 
 _MODULE_PATH: str = "image_viewer.viewer"
 
+# mypy: disable-error-code="method-assign"
+
 
 def test_pixel_scaling(viewer: ViewerApp):
     """Should correctly scale to screen size"""


### PR DESCRIPTION
When bad images were detected, the index pointing to the current image always tried to go forward. This works if the index is not at the start/end and if you are going forwards, but not if you are going backwards in the list or wrapping around. These changes account for all edge cases.

Fixes issue where moving to new directory could crash since index could end up out of bounds if its at a value larger then the new directories size.

Fixed issue where dropdown menu was always marked as needing to be updated.

Bump Nuitka to 2.7.13.

Updated more docstrings to reST.